### PR TITLE
Completed mappings in MobSpawnHelper

### DIFF
--- a/mappings/net/minecraft/class_1714.mapping
+++ b/mappings/net/minecraft/class_1714.mapping
@@ -1,4 +1,0 @@
-CLASS net/minecraft/class_1714
-	FIELD field_7196 weight I
-	METHOD <init> (I)V
-		ARG 1 weight

--- a/mappings/net/minecraft/entity/EndCrystalEntity.mapping
+++ b/mappings/net/minecraft/entity/EndCrystalEntity.mapping
@@ -1,4 +1,6 @@
 CLASS net/minecraft/class_1878 net/minecraft/entity/EndCrystalEntity
+	FIELD field_7996 age I
+	FIELD field_7997 explosionCountdown I
 	METHOD <init> (Lnet/minecraft/class_99;DDD)V
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -69,6 +69,7 @@ CLASS net/minecraft/class_1745 net/minecraft/entity/Entity
 	METHOD method_10542 dropStack (Lnet/minecraft/class_2056;F)Lnet/minecraft/class_1893;
 	METHOD method_10544 isInvulnerableTo ()Z
 	METHOD method_10546 updatePosition (DDD)V
+	METHOD method_11363 yShadowOrigin ()F
 	METHOD method_6261 getTranslationKey ()Ljava/lang/String;
 	METHOD method_6895 getEntityId ()I
 	METHOD method_6897 getDataTracker ()Lnet/minecraft/class_1761;

--- a/mappings/net/minecraft/entity/MobSpawnEntry.mapping
+++ b/mappings/net/minecraft/entity/MobSpawnEntry.mapping
@@ -1,0 +1,9 @@
+CLASS net/minecraft/class_116 net/minecraft/entity/MobSpawnEntry
+	FIELD field_439 type Ljava/lang/Class;
+	FIELD field_440 maxGroupSize I
+	FIELD field_441 minGroupSize I
+	METHOD <init> (Ljava/lang/Class;III)V
+		ARG 1 type
+		ARG 2 weight
+		ARG 3 maxGroupSize
+		ARG 4 minGroupSize

--- a/mappings/net/minecraft/entity/MobSpawnerHelper.mapping
+++ b/mappings/net/minecraft/entity/MobSpawnerHelper.mapping
@@ -1,1 +1,25 @@
 CLASS net/minecraft/class_107 net/minecraft/entity/MobSpawnerHelper
+	FIELD field_9155 spawnedMobs Ljava/util/HashMap;
+	METHOD method_498 getRandomPosInChunk (Lnet/minecraft/class_99;II)Lnet/minecraft/class_2082;
+		ARG 0 world
+		ARG 1 x
+		ARG 2 z
+	METHOD method_499 populateEntities (Lnet/minecraft/class_99;Lnet/minecraft/class_113;IIIILjava/util/Random;)V
+		ARG 0 world
+		ARG 1 biome
+		ARG 2 chunkStartX
+		ARG 3 chunkStartY
+		ARG 4 chunkSizeX
+		ARG 5 chunkSizeY
+		ARG 6 random
+	METHOD method_500 spawnEntities (Lnet/minecraft/class_2571;ZZZ)I
+		ARG 1 serverWorld
+		ARG 2 allowAnimals
+		ARG 3 allowMonsters
+		ARG 4 shouldSpawnAnimals
+	METHOD method_8560 canSpawn (Lnet/minecraft/class_2631;Lnet/minecraft/class_99;III)Z
+		ARG 0 spawnGroup
+		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z

--- a/mappings/net/minecraft/entity/SpawnGroup.mapping
+++ b/mappings/net/minecraft/entity/SpawnGroup.mapping
@@ -4,8 +4,13 @@ CLASS net/minecraft/class_2631 net/minecraft/entity/SpawnGroup
 	FIELD field_11470 spawnableInBlock Lnet/minecraft/class_591;
 	FIELD field_11471 peaceful Z
 	FIELD field_11472 rare Z
+	METHOD <init> (Ljava/lang/String;ILjava/lang/Class;ILnet/minecraft/class_591;ZZ)V
+		ARG 3 groupClass
+		ARG 4 capacity
+		ARG 5 spwanableInBlock
 	METHOD method_10612 getGroupClass ()Ljava/lang/Class;
 	METHOD method_10613 getCapacity ()I
 	METHOD method_10614 getSpawnableInBlock ()Lnet/minecraft/class_591;
 	METHOD method_10615 isPeaceful ()Z
 	METHOD method_10616 isRare ()Z
+	METHOD values ()[Lnet/minecraft/class_2631;

--- a/mappings/net/minecraft/entity/mob/MobEntity.mapping
+++ b/mappings/net/minecraft/entity/mob/MobEntity.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_2630 net/minecraft/entity/mob/MobEntity
 	FIELD field_11444 experiencePoints I
+	FIELD field_11452 persistence Z
 	FIELD field_11454 teleporting Z
 	FIELD field_11455 holdingEntity Lnet/minecraft/class_1745;
 	FIELD field_11457 goalSelector Lnet/minecraft/class_2641;
@@ -9,6 +10,7 @@ CLASS net/minecraft/class_2630 net/minecraft/entity/mob/MobEntity
 	METHOD method_10587 attachLeash (Lnet/minecraft/class_1745;Z)V
 		ARG 1 entity
 		ARG 2 sendPacket
+	METHOD method_10594 getPersistence ()Z
 	METHOD method_10605 getNavigation ()Lnet/minecraft/class_2651;
 	METHOD method_7183 getDefaultDrop ()Lnet/minecraft/class_2054;
 	METHOD method_7189 canAttackEntity (Ljava/lang/Class;)Z

--- a/mappings/net/minecraft/server/world/ServerWorld.mapping
+++ b/mappings/net/minecraft/server/world/ServerWorld.mapping
@@ -44,6 +44,11 @@ CLASS net/minecraft/class_2571 net/minecraft/server/world/ServerWorld
 		ARG 11 deltaY
 		ARG 13 deltaZ
 		ARG 15 speed
+	METHOD method_10369 pickSpawnEntry (Lnet/minecraft/class_2631;III)Lnet/minecraft/class_116;
+		ARG 1 spawnGroup
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD method_10372 skipNightOrThunder ()V
 	METHOD method_10373 arePlayersSleptEnough ()Z
 	METHOD method_10374 resetIdleTimeout ()V

--- a/mappings/net/minecraft/util/WeightedPicker.mapping
+++ b/mappings/net/minecraft/util/WeightedPicker.mapping
@@ -1,3 +1,10 @@
 CLASS net/minecraft/class_1713 net/minecraft/util/WeightedPicker
+	METHOD method_10513 pickWeightedEntry (Ljava/util/Random;Ljava/util/Collection;)Lnet/minecraft/class_1714;
+		ARG 0 random
+		ARG 1 collection
+	METHOD method_10514 pickWeightedEntry (Ljava/util/Random;Ljava/util/Collection;I)Lnet/minecraft/class_1714;
+		ARG 0 random
+		ARG 1 collection
+		ARG 2 totalWeight
 	METHOD method_6726 getRate (Ljava/util/Collection;)I
 		ARG 0 entries

--- a/mappings/net/minecraft/world/WeightedEntry.mapping
+++ b/mappings/net/minecraft/world/WeightedEntry.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_1714 net/minecraft/world/WeightedEntry
+	FIELD field_7196 weight I
+	METHOD <init> (I)V
+		ARG 1 weight

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -138,6 +138,21 @@ CLASS net/minecraft/class_99 net/minecraft/world/World
 		ARG 2 status
 	METHOD method_328 getClosestPlayer (Lnet/minecraft/class_1745;D)Lnet/minecraft/class_2674;
 		ARG 1 entity
+	METHOD method_329 createExplosion (Lnet/minecraft/class_1745;DDDFZ)Lnet/minecraft/class_93;
+		ARG 1 entity
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 power
+		ARG 9 shouldDestroy
+	METHOD method_330 createExplosion (Lnet/minecraft/class_1745;DDDFZZ)Lnet/minecraft/class_93;
+		ARG 1 entity
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 power
+		ARG 9 createFire
+		ARG 10 shouldDestroy
 	METHOD method_334 playSound (Lnet/minecraft/class_1745;Ljava/lang/String;FF)V
 		ARG 1 entity
 		ARG 2 sound

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -19,8 +19,11 @@ CLASS net/minecraft/class_99 net/minecraft/world/World
 	FIELD field_9125 pendingBlockEntities Ljava/util/List;
 	FIELD field_9126 removedBlockEntities Ljava/util/List;
 	FIELD field_9127 executeTicksImmediately Z
+	FIELD field_9128 entities Ljava/util/List;
+	FIELD field_9129 entitiesToRemove Ljava/util/List;
 	FIELD field_9130 blockEntities Ljava/util/List;
 	FIELD field_9131 players Ljava/util/List;
+	FIELD field_9132 tickingEntities Ljava/util/List;
 	FIELD field_9133 ambientDarkness I
 	FIELD field_9135 difficulty Lnet/minecraft/class_1721;
 	FIELD field_9136 random Ljava/util/Random;
@@ -210,6 +213,7 @@ CLASS net/minecraft/class_99 net/minecraft/world/World
 	METHOD method_433 isSunny ()Z
 	METHOD method_435 getMoonPhase ()I
 	METHOD method_437 getMoonSize ()F
+	METHOD method_8460 maxSpawnHeight ()I
 	METHOD method_8462 getEntityById (I)Lnet/minecraft/class_1745;
 		ARG 1 id
 	METHOD method_8463 isRegionLoaded (IIII)Z
@@ -250,6 +254,8 @@ CLASS net/minecraft/class_99 net/minecraft/world/World
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
+	METHOD method_8475 getSpawnCap (Ljava/lang/Class;)I
+		ARG 1 groupClass
 	METHOD method_8476 getEntitiesByClass (Ljava/lang/Class;Lnet/minecraft/class_646;)Ljava/util/List;
 	METHOD method_8478 getEntities (Ljava/lang/Class;Lnet/minecraft/class_646;Lnet/minecraft/class_2625;)Ljava/util/List;
 	METHOD method_8479 playSound (Ljava/lang/String;DDDDDD)V
@@ -346,6 +352,9 @@ CLASS net/minecraft/class_99 net/minecraft/world/World
 		ARG 2 y
 		ARG 3 z
 		ARG 4 dir
+	METHOD method_8521 getSurfaceHeight (II)I
+		ARG 1 x
+		ARG 2 y
 	METHOD method_8522 isTopOfColumn (III)Z
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -96,3 +96,4 @@ CLASS net/minecraft/class_113 net/minecraft/world/biome/Biome
 	METHOD method_545 asClass ()Ljava/lang/Class;
 	METHOD method_546 getBiomeTemperature ()Lnet/minecraft/class_2089;
 	METHOD method_547 getBiomes ()[Lnet/minecraft/class_113;
+	METHOD method_8567 getSpawnEntries (Lnet/minecraft/class_2631;)Ljava/util/List;

--- a/mappings/net/minecraft/world/chunk/Chunk.mapping
+++ b/mappings/net/minecraft/world/chunk/Chunk.mapping
@@ -51,6 +51,7 @@ CLASS net/minecraft/class_399 net/minecraft/world/chunk/Chunk
 		ARG 2 y
 		ARG 3 sectionZ
 	METHOD method_1390 isEmpty ()Z
+	METHOD method_1394 getHighestNonEmptySection ()I
 	METHOD method_1398 getSections ()[Lnet/minecraft/class_401;
 	METHOD method_1401 isPopulated ()Z
 	METHOD method_1403 getChunkPos ()Lnet/minecraft/class_92;

--- a/mappings/net/minecraft/world/chunk/ChunkProvider.mapping
+++ b/mappings/net/minecraft/world/chunk/ChunkProvider.mapping
@@ -12,3 +12,5 @@ CLASS net/minecraft/class_396 net/minecraft/world/chunk/ChunkProvider
 	METHOD method_1332 canSave ()Z
 	METHOD method_1333 getChunkProviderName ()Ljava/lang/String;
 	METHOD method_1334 getLoadedChunksCount ()I
+	METHOD method_8912 spawnableMobs (Lnet/minecraft/class_2631;III)Ljava/util/List;
+		ARG 1 spawnGroup

--- a/mappings/net/minecraft/world/explosion/Explosion.mapping
+++ b/mappings/net/minecraft/world/explosion/Explosion.mapping
@@ -4,6 +4,8 @@ CLASS net/minecraft/class_93 net/minecraft/world/explosion/Explosion
 	FIELD field_231 y D
 	FIELD field_232 z D
 	FIELD field_234 power F
+	FIELD field_9112 createFire Z
+	FIELD field_9113 shouldDestroy Z
 	METHOD method_205 collectBlocksAndDamageEntities ()V
 	METHOD method_206 affectWorld (Z)V
 	METHOD method_207 getAffectedPlayers ()Ljava/util/Map;


### PR DESCRIPTION
Completed all mappings in the MobSpawnHelper class
Created mappings for methods and fields from the following classes that are used in MobSpawnHelper
- `SpawnGroup`
- `MobEntity`
- `ServerWorld`
- `WeightedPicker`
- `World`
- `Biome` 
- `Chunk`
- `ChunkProvider`

Completely mapped the following (small) unmapped classes:
- `MobSpawnEntry` (previously `class_116`)
- `WeightedEntry` (previously `class_1714`)
