### PR TITLE
More work on different classes and classes I forgot to add again to vcs after name change

### DIFF
--- a/mappings/net/minecraft/block/Block.mapping
+++ b/mappings/net/minecraft/block/Block.mapping
@@ -196,6 +196,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
+		ARG 5 vec1
+		ARG 6 vec2
 	METHOD method_658 onSteppedOn (Lnet/minecraft/class_99;IIILnet/minecraft/class_1745;)V
 		COMMENT Runs every time an entity steps on the Block.
 		COMMENT Used by redstone ore to change it's state.
@@ -562,11 +564,12 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
-	METHOD method_8637 (Lnet/minecraft/class_104;IIII)Lnet/minecraft/class_2616;
+	METHOD method_8637 getBlockState (Lnet/minecraft/class_104;IIII)Lnet/minecraft/class_2616;
 		ARG 1 world
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
+		ARG 5 id
 	METHOD method_8638 getMaterialColor (I)Lnet/minecraft/class_592;
 		ARG 1 id
 	METHOD method_8639 getHardness (Lnet/minecraft/class_99;III)F
@@ -580,7 +583,7 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 3 y
 		ARG 4 z
 		ARG 5 meta
-	METHOD method_8641 (Lnet/minecraft/class_99;III)Lnet/minecraft/class_646;
+	METHOD method_8641 getSelectionBox (Lnet/minecraft/class_99;III)Lnet/minecraft/class_646;
 		ARG 1 world
 		ARG 2 x
 		ARG 3 y
@@ -593,6 +596,8 @@ CLASS net/minecraft/class_160 net/minecraft/block/Block
 		ARG 5 meta
 	METHOD method_8643 getSprite (I)Lnet/minecraft/class_2616;
 		ARG 1 dir
+	METHOD method_8645 createItemStack (I)Lnet/minecraft/class_2056;
+		ARG 1 damage
 	METHOD method_8646 isSupported (Lnet/minecraft/class_99;III)Z
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/block/CactusBlock.mapping
+++ b/mappings/net/minecraft/block/CactusBlock.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_169 net/minecraft/block/CactusBlock
+	FIELD field_9350 spriteTop Lnet/minecraft/class_2616;
+	FIELD field_9351 spriteBottom Lnet/minecraft/class_2616;

--- a/mappings/net/minecraft/block/CakeBlock.mapping
+++ b/mappings/net/minecraft/block/CakeBlock.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_2100 net/minecraft/block/CakeBlock
+	FIELD field_9352 spriteInner Lnet/minecraft/class_2616;
+	FIELD field_9353 spriteTop Lnet/minecraft/class_2616;
+	FIELD field_9354 spriteBottom Lnet/minecraft/class_2616;
 	METHOD method_8660 tryEatCake (Lnet/minecraft/class_99;IIILnet/minecraft/class_2674;)V
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/block/CarpetBlock.mapping
+++ b/mappings/net/minecraft/block/CarpetBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_2191 net/minecraft/block/CarpetBlock
+	METHOD method_8833 setBoundingBox (I)V
 	METHOD method_8834 tryBreak (Lnet/minecraft/class_99;III)Z
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/block/CarrotsBlock.mapping
+++ b/mappings/net/minecraft/block/CarrotsBlock.mapping
@@ -1,1 +1,2 @@
 CLASS net/minecraft/class_2101 net/minecraft/block/CarrotsBlock
+	FIELD field_9355 growthStageSprite [Lnet/minecraft/class_2616;

--- a/mappings/net/minecraft/block/CauldronBlock.mapping
+++ b/mappings/net/minecraft/block/CauldronBlock.mapping
@@ -1,4 +1,7 @@
 CLASS net/minecraft/class_172 net/minecraft/block/CauldronBlock
+	FIELD field_9356 spriteBottom Lnet/minecraft/class_2616;
+	FIELD field_9357 spriteInner Lnet/minecraft/class_2616;
+	FIELD field_9358 spriteTop Lnet/minecraft/class_2616;
 	METHOD method_8661 setLevel (Lnet/minecraft/class_99;IIII)V
 		ARG 1 world
 		ARG 2 x
@@ -7,3 +10,7 @@ CLASS net/minecraft/class_172 net/minecraft/block/CauldronBlock
 		ARG 5 level
 	METHOD method_8662 getLevel (I)I
 		ARG 0 meta
+	METHOD method_8663 setLevel (I)F
+		ARG 0 level
+	METHOD method_8664 getHorizontalSprite (Ljava/lang/String;)Lnet/minecraft/class_2616;
+		ARG 0 sprite

--- a/mappings/net/minecraft/block/CocoaBlock.mapping
+++ b/mappings/net/minecraft/block/CocoaBlock.mapping
@@ -1,2 +1,5 @@
 CLASS net/minecraft/class_2103 net/minecraft/block/CocoaBlock
+	FIELD field_9361 cocoaSprite [Lnet/minecraft/class_2616;
+	METHOD method_8669 setSprite (I)Lnet/minecraft/class_2616;
+		ARG 1 meta
 	METHOD method_8670 getNextGrowthStage (I)I

--- a/mappings/net/minecraft/block/CraftingTableBlock.mapping
+++ b/mappings/net/minecraft/block/CraftingTableBlock.mapping
@@ -1,1 +1,3 @@
 CLASS net/minecraft/class_2107 net/minecraft/block/CraftingTableBlock
+	FIELD field_9363 spriteSide Lnet/minecraft/class_2616;
+	FIELD field_9364 spriteFront Lnet/minecraft/class_2616;

--- a/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
+++ b/mappings/net/minecraft/block/DaylightDetectorBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_184 net/minecraft/block/DaylightDetectorBlock
+	FIELD field_9366 sprites [Lnet/minecraft/class_2616;
 	METHOD method_8681 update (Lnet/minecraft/class_99;III)V
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/block/DetectorRailBlock.mapping
+++ b/mappings/net/minecraft/block/DetectorRailBlock.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_2109 net/minecraft/block/DetectorRailBlock
+	FIELD field_9367 sprites [Lnet/minecraft/class_2616;
 	METHOD method_8682 updatePower (Lnet/minecraft/class_99;IIII)V
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/block/DirtBlock.mapping
+++ b/mappings/net/minecraft/block/DirtBlock.mapping
@@ -1,1 +1,4 @@
 CLASS net/minecraft/class_2111 net/minecraft/block/DirtBlock
+	FIELD field_9368 spriteSide Lnet/minecraft/class_2616;
+	FIELD field_9369 dirtStates [Ljava/lang/String;
+	FIELD field_9370 spriteTop Lnet/minecraft/class_2616;

--- a/mappings/net/minecraft/block/DispenserBlock.mapping
+++ b/mappings/net/minecraft/block/DispenserBlock.mapping
@@ -8,6 +8,8 @@ CLASS net/minecraft/class_191 net/minecraft/block/DispenserBlock
 		ARG 0 ptr
 	METHOD method_811 getBehaviorForItem (Lnet/minecraft/class_2056;)Lnet/minecraft/class_1387;
 		ARG 1 stack
+	METHOD method_8697 getCubeFace (I)Lnet/minecraft/class_1009;
+		ARG 0 id
 	METHOD method_8698 dispense (Lnet/minecraft/class_99;III)V
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/block/DoorBlock.mapping
+++ b/mappings/net/minecraft/block/DoorBlock.mapping
@@ -1,12 +1,21 @@
 CLASS net/minecraft/class_192 net/minecraft/block/DoorBlock
+	FIELD field_9376 spriteUpper [Lnet/minecraft/class_2616;
+	FIELD field_9377 spriteLower [Lnet/minecraft/class_2616;
 	METHOD method_8700 updateOpenState (Lnet/minecraft/class_99;IIIZ)V
 		ARG 1 world
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
 		ARG 5 powered
-	METHOD method_8702 (Lnet/minecraft/class_104;III)I
+	METHOD method_8701 updateBoundingBox (I)V
+		ARG 1 id
+	METHOD method_8702 getDoorState (Lnet/minecraft/class_104;III)I
 		ARG 1 world
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD method_8703 getDoorStateView (Lnet/minecraft/class_104;III)Z
+		ARG 1 worldView
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z

--- a/mappings/net/minecraft/block/DoublePlantBlock.mapping
+++ b/mappings/net/minecraft/block/DoublePlantBlock.mapping
@@ -3,6 +3,9 @@ CLASS net/minecraft/class_2112 net/minecraft/block/DoublePlantBlock
 	FIELD field_9379 topSprites [Lnet/minecraft/class_2616;
 	FIELD field_9380 plantSprites [Ljava/lang/String;
 	FIELD field_9381 sunflowerSprite [Lnet/minecraft/class_2616;
+	METHOD method_8705 getSprite (ZI)Lnet/minecraft/class_2616;
+		ARG 1 isTop
+		ARG 2 id
 	METHOD method_8706 tryHarvest (Lnet/minecraft/class_99;IIIILnet/minecraft/class_2674;)Z
 		ARG 1 world
 		ARG 2 x

--- a/mappings/net/minecraft/block/entity/BlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/BlockEntity.mapping
@@ -34,9 +34,11 @@ CLASS net/minecraft/class_2193 net/minecraft/block/entity/BlockEntity
 	METHOD method_8849 createFromTag (Lnet/minecraft/class_1405;)Lnet/minecraft/class_2193;
 		ARG 0 tag
 	METHOD method_8850 tick ()V
+	METHOD method_8851 getSquaredRenderDistance ()D
 	METHOD method_8852 hasWorld ()Z
 	METHOD method_8853 getCachedBlockMeta ()I
 	METHOD method_8854 getCachedBlock ()Lnet/minecraft/class_160;
 	METHOD method_8855 isRemoved ()Z
 	METHOD method_8856 cancelRemoval ()V
 	METHOD method_8857 clearBlockCache ()V
+	METHOD method_8858 getBlockToId ()Ljava/util/Map;

--- a/mappings/net/minecraft/block/entity/CrashedBlockTypeCallable.mapping
+++ b/mappings/net/minecraft/block/entity/CrashedBlockTypeCallable.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_2195 net/minecraft/block/entity/CrashedBlockTypeCallable
+	FIELD field_9537 anonBlockEntity Lnet/minecraft/class_2193;
+	METHOD <init> (Lnet/minecraft/class_2193;)V
+		ARG 1 blockEntity
+	METHOD call ()Ljava/lang/Object;

--- a/mappings/net/minecraft/block/entity/CrashedNameCallable.mapping
+++ b/mappings/net/minecraft/block/entity/CrashedNameCallable.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_2194 net/minecraft/block/entity/CrashedName
+CLASS net/minecraft/class_2194 net/minecraft/block/entity/CrashedNameCallable
 	FIELD field_9536 anonBlockEntity Lnet/minecraft/class_2193;
 	METHOD <init> (Lnet/minecraft/class_2193;)V
 		ARG 1 blockEntity

--- a/mappings/net/minecraft/block/entity/FurnaceBlockEntity.mapping
+++ b/mappings/net/minecraft/block/entity/FurnaceBlockEntity.mapping
@@ -3,6 +3,7 @@ CLASS net/minecraft/class_360 net/minecraft/block/entity/FurnaceBlockEntity
 	FIELD field_1447 fuelTime I
 	FIELD field_1450 totalCookTime I
 	FIELD field_1451 customName Ljava/lang/String;
+	FIELD field_9566 cookTime I
 	METHOD method_1141 setCustomName (Ljava/lang/String;)V
 		ARG 1 name
 	METHOD method_1144 getBurnTime (Lnet/minecraft/class_2056;)I

--- a/mappings/net/minecraft/client/render/model/CubeFace.mapping
+++ b/mappings/net/minecraft/client/render/model/CubeFace.mapping
@@ -1,1 +1,14 @@
 CLASS net/minecraft/class_1009 net/minecraft/client/render/model/CubeFace
+	FIELD field_10837 id I
+	FIELD field_4229 DOWN Lnet/minecraft/class_1009;
+	FIELD field_4230 UP Lnet/minecraft/class_1009;
+	FIELD field_4231 NORTH Lnet/minecraft/class_1009;
+	FIELD field_4232 SOUTH Lnet/minecraft/class_1009;
+	FIELD field_4233 WEST Lnet/minecraft/class_1009;
+	FIELD field_4234 EAST Lnet/minecraft/class_1009;
+	FIELD field_4235 ALL_DIRECTIONS [Lnet/minecraft/class_1009;
+	METHOD <init> (Ljava/lang/String;IIIIII)V
+		ARG 3 id
+	METHOD method_9830 byId (I)Lnet/minecraft/class_1009;
+		ARG 0 id
+	METHOD values ()[Lnet/minecraft/class_1009;

--- a/mappings/net/minecraft/client/texture/ISprite.mapping
+++ b/mappings/net/minecraft/client/texture/ISprite.mapping
@@ -1,0 +1,10 @@
+CLASS net/minecraft/class_2616 net/minecraft/client/texture/ISprite
+	METHOD method_10526 getWidth ()I
+	METHOD method_10527 getUFrame (D)F
+	METHOD method_10528 getHeight ()I
+	METHOD method_10529 getVFrame (D)F
+	METHOD method_10530 getUMin ()F
+	METHOD method_10531 getUMax ()F
+	METHOD method_10532 getVMin ()F
+	METHOD method_10533 getVMax ()F
+	METHOD method_10534 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/client/texture/Sprite.mapping
+++ b/mappings/net/minecraft/client/texture/Sprite.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2615 net/minecraft/client/texture/Sprite

--- a/mappings/net/minecraft/client/texture/SpriteLoader.mapping
+++ b/mappings/net/minecraft/client/texture/SpriteLoader.mapping
@@ -1,3 +1,3 @@
-CLASS net/minecraft/class_2617 net/minecraft/SpriteLoader
+CLASS net/minecraft/class_2617 net/minecraft/client/texture/SpriteLoader
 	METHOD method_10535 addSpriteToLoad (Ljava/lang/String;)Lnet/minecraft/class_2616;
 		ARG 1 name

--- a/mappings/net/minecraft/entity/Entity.mapping
+++ b/mappings/net/minecraft/entity/Entity.mapping
@@ -142,6 +142,7 @@ CLASS net/minecraft/class_1745 net/minecraft/entity/Entity
 		ARG 1 values
 	METHOD method_6947 toListTag ([F)Lnet/minecraft/class_1411;
 		ARG 1 values
+	METHOD method_6948 slowdownMovementSpeed ()V
 	METHOD method_6950 getHeadRotation ()F
 	METHOD method_6951 isAttackable ()Z
 	METHOD method_6952 getSafeFallDistance ()I

--- a/mappings/net/minecraft/entity/ItemEntity.mapping
+++ b/mappings/net/minecraft/entity/ItemEntity.mapping
@@ -1,4 +1,5 @@
 CLASS net/minecraft/class_1893 net/minecraft/entity/ItemEntity
+	FIELD field_11643 pickupDelay I
 	FIELD field_8132 hoverHeight F
 	FIELD field_8133 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_8134 age I
@@ -16,11 +17,16 @@ CLASS net/minecraft/class_1893 net/minecraft/entity/ItemEntity
 		ARG 4 y
 		ARG 6 z
 		ARG 8 stack
+	METHOD method_10736 getItemStack ()Lnet/minecraft/class_2056;
+	METHOD method_7760 canStack (Lnet/minecraft/class_1893;)Z
+		ARG 1 item
 	METHOD method_7761 setItemStack (Lnet/minecraft/class_2056;)V
+		ARG 1 stack
 	METHOD method_7762 setOwner (Ljava/lang/String;)V
 		ARG 1 owner
 	METHOD method_7763 setThrower (Ljava/lang/String;)V
 		ARG 1 thrower
+	METHOD method_7764 getAge ()V
 	METHOD method_7766 getOwner ()Ljava/lang/String;
 	METHOD method_7767 getThrower ()Ljava/lang/String;
 	METHOD method_7775 tryMerge ()V

--- a/mappings/net/minecraft/entity/SpawnGroup.mapping
+++ b/mappings/net/minecraft/entity/SpawnGroup.mapping
@@ -1,4 +1,8 @@
 CLASS net/minecraft/class_2631 net/minecraft/entity/SpawnGroup
+	FIELD field_11464 MONSTER Lnet/minecraft/class_2631;
+	FIELD field_11465 CREATURE Lnet/minecraft/class_2631;
+	FIELD field_11466 AMBIENT Lnet/minecraft/class_2631;
+	FIELD field_11467 WATER_CREATURE Lnet/minecraft/class_2631;
 	FIELD field_11468 groupClass Ljava/lang/Class;
 	FIELD field_11469 capacity I
 	FIELD field_11470 spawnableInBlock Lnet/minecraft/class_591;
@@ -8,9 +12,10 @@ CLASS net/minecraft/class_2631 net/minecraft/entity/SpawnGroup
 		ARG 3 groupClass
 		ARG 4 capacity
 		ARG 5 spwanableInBlock
+		ARG 6 isPeacefull
+		ARG 7 isRare
 	METHOD method_10612 getGroupClass ()Ljava/lang/Class;
 	METHOD method_10613 getCapacity ()I
 	METHOD method_10614 getSpawnableInBlock ()Lnet/minecraft/class_591;
 	METHOD method_10615 isPeaceful ()Z
 	METHOD method_10616 isRare ()Z
-	METHOD values ()[Lnet/minecraft/class_2631;

--- a/mappings/net/minecraft/entity/ai/goal/TemptGoal.mapping
+++ b/mappings/net/minecraft/entity/ai/goal/TemptGoal.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2646 net/minecraft/entity/ai/goal/TemptGoal

--- a/mappings/net/minecraft/entity/attribute/AbstractEntityAttribute.mapping
+++ b/mappings/net/minecraft/entity/attribute/AbstractEntityAttribute.mapping
@@ -2,5 +2,8 @@ CLASS net/minecraft/class_1768 net/minecraft/entity/attribute/AbstractEntityAttr
 	FIELD field_7553 id Ljava/lang/String;
 	FIELD field_7554 defaultValue D
 	FIELD field_7555 tracked Z
+	METHOD <init> (Ljava/lang/String;D)V
+		ARG 1 id
+		ARG 2 defaultValue
 	METHOD method_7312 setTracked (Z)Lnet/minecraft/class_1768;
 		ARG 1 tracked

--- a/mappings/net/minecraft/entity/attribute/AbstractEntityAttributeContainer.mapping
+++ b/mappings/net/minecraft/entity/attribute/AbstractEntityAttributeContainer.mapping
@@ -2,13 +2,15 @@ CLASS net/minecraft/class_2635 net/minecraft/entity/attribute/AbstractEntityAttr
 	FIELD field_11520 attributesByID Ljava/util/Map;
 	FIELD field_11521 attributesByName Ljava/util/Map;
 	METHOD method_10634 getAllEntityAttributes ()Ljava/util/Collection;
-	METHOD method_10635 removeAttributeModifier (Lcom/google/common/collect/Multimap;)V
+	METHOD method_10635 removeAllAttributes (Lcom/google/common/collect/Multimap;)V
+		ARG 1 multimap
 	METHOD method_10636 getEntityAttributes (Ljava/lang/String;)Lnet/minecraft/class_1766;
 		ARG 1 name
 	METHOD method_10637 getEntityAttributeInstance (Lnet/minecraft/class_1765;)Lnet/minecraft/class_1766;
 		ARG 1 attribute
 	METHOD method_10638 setTracked (Lnet/minecraft/class_1770;)V
 		ARG 1 attributeInstance
-	METHOD method_10639 addTempararyAttributeModifier (Lcom/google/common/collect/Multimap;)V
+	METHOD method_10639 replaceAllAttributes (Lcom/google/common/collect/Multimap;)V
+		ARG 1 multimap
 	METHOD method_10640 registerAttribute (Lnet/minecraft/class_1765;)Lnet/minecraft/class_1766;
 		ARG 1 attribute

--- a/mappings/net/minecraft/entity/attribute/ClampedEntityAttribute.mapping
+++ b/mappings/net/minecraft/entity/attribute/ClampedEntityAttribute.mapping
@@ -2,6 +2,11 @@ CLASS net/minecraft/class_1772 net/minecraft/entity/attribute/ClampedEntityAttri
 	FIELD field_7569 minValue D
 	FIELD field_7570 maxValue D
 	FIELD field_7571 name Ljava/lang/String;
+	METHOD <init> (Ljava/lang/String;DDD)V
+		ARG 1 name
+		ARG 2 defaultValue
+		ARG 4 minValue
+		ARG 6 maxValue
 	METHOD method_7328 setName (Ljava/lang/String;)Lnet/minecraft/class_1772;
 		ARG 1 name
 	METHOD method_7329 getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
@@ -1,4 +1,4 @@
 CLASS net/minecraft/class_2635 net/minecraft/entity/attribute/EntityAttributeContainer
-	METHOD method_10635 removeAll (Lcom/google/common/collect/Multimap;)V
-	METHOD method_10639 replaceAll (Lcom/google/common/collect/Multimap;)V
-	METHOD method_10640 register (Lnet/minecraft/class_1765;)Lnet/minecraft/class_1766;
+	METHOD method_10635 removeAllAttributes (Lcom/google/common/collect/Multimap;)V
+	METHOD method_10639 replaceAllAttributes (Lcom/google/common/collect/Multimap;)V
+	METHOD method_10640 registerAttribute (Lnet/minecraft/class_1765;)Lnet/minecraft/class_1766;

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
@@ -1,4 +1,5 @@
-CLASS net/minecraft/class_2635 net/minecraft/entity/attribute/EntityAttributeContainer
-	METHOD method_10635 removeAllAttributes (Lcom/google/common/collect/Multimap;)V
-	METHOD method_10639 replaceAllAttributes (Lcom/google/common/collect/Multimap;)V
-	METHOD method_10640 registerAttribute (Lnet/minecraft/class_1765;)Lnet/minecraft/class_1766;
+CLASS net/minecraft/class_2636 net/minecraft/entity/attribute/EntityAttributeContainer
+	FIELD field_11522 instancesByName Ljava/util/Map;
+	FIELD field_11523 trackedAttributes Ljava/util/Set;
+	METHOD method_10642 getTrackedAttributes ()Ljava/util/Set;
+	METHOD method_10644 buildTrackedAttributesCollection ()Ljava/util/Collection;

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeContainer.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_2635 net/minecraft/entity/attribute/EntityAttributeContainer
+	METHOD method_10635 removeAll (Lcom/google/common/collect/Multimap;)V
+	METHOD method_10639 replaceAll (Lcom/google/common/collect/Multimap;)V
+	METHOD method_10640 register (Lnet/minecraft/class_1765;)Lnet/minecraft/class_1766;

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeInstance.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeInstance.mapping
@@ -9,5 +9,6 @@ CLASS net/minecraft/class_1766 net/minecraft/entity/attribute/EntityAttributeIns
 		ARG 1 modifier
 	METHOD method_7302 getAttributeModifiers ()Ljava/util/Collection;
 	METHOD method_7303 removeAttributeModifiers (Lnet/minecraft/class_1767;)V
+		ARG 1 attributeModifier
 	METHOD method_7304 clearModifiers ()V
 	METHOD method_7305 getValue ()D

--- a/mappings/net/minecraft/entity/attribute/EntityAttributeInstanceImpl.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributeInstanceImpl.mapping
@@ -1,8 +1,16 @@
 CLASS net/minecraft/class_1770 net/minecraft/entity/attribute/EntityAttributeInstanceImpl
+	FIELD field_7559 attributeContainer Lnet/minecraft/class_2635;
+	FIELD field_7560 attribute Lnet/minecraft/class_1765;
+	FIELD field_7561 modifiersById Ljava/util/Map;
 	FIELD field_7562 modifiersByName Ljava/util/Map;
 	FIELD field_7563 modifiersByUuid Ljava/util/Map;
 	FIELD field_7564 baseValue D
 	FIELD field_7565 needsRefresh Z
 	FIELD field_7566 cachedValue D
+	METHOD <init> (Lnet/minecraft/class_2635;Lnet/minecraft/class_1765;)V
+		ARG 1 container
+		ARG 2 attribute
+	METHOD method_10641 getModifiersById (I)Ljava/util/Collection;
+		ARG 1 id
 	METHOD method_7322 invalidateCache ()V
 	METHOD method_7323 computeValue ()D

--- a/mappings/net/minecraft/entity/attribute/EntityAttributes.mapping
+++ b/mappings/net/minecraft/entity/attribute/EntityAttributes.mapping
@@ -5,12 +5,14 @@ CLASS net/minecraft/class_1932 net/minecraft/entity/attribute/EntityAttributes
 	FIELD field_8234 GENERIC_MOVEMENT_SPEED Lnet/minecraft/class_1765;
 	FIELD field_8235 GENERIC_ATTACK_DAMAGE Lnet/minecraft/class_1765;
 	FIELD field_8236 LOGGER Lorg/apache/logging/log4j/Logger;
+	METHOD method_10808 fromTag (Lnet/minecraft/class_1405;)Lnet/minecraft/class_1767;
+		ARG 0 compoundTag
 	METHOD method_7876 toTag (Lnet/minecraft/class_1766;)Lnet/minecraft/class_1405;
 		ARG 0 instance
 	METHOD method_7877 fromTag (Lnet/minecraft/class_1766;Lnet/minecraft/class_1405;)V
 		ARG 0 instance
 		ARG 1 tag
-	METHOD method_7878 (Lnet/minecraft/class_1767;)Lnet/minecraft/class_1405;
+	METHOD method_7878 toTag (Lnet/minecraft/class_1767;)Lnet/minecraft/class_1405;
 		ARG 0 modifier
 	METHOD method_7879 toTag (Lnet/minecraft/class_2635;)Lnet/minecraft/class_1411;
 		ARG 0 container

--- a/mappings/net/minecraft/entity/damage/DamageSource.mapping
+++ b/mappings/net/minecraft/entity/damage/DamageSource.mapping
@@ -5,6 +5,7 @@ CLASS net/minecraft/class_1733 net/minecraft/entity/damage/DamageSource
 	FIELD field_7250 IN_WALL Lnet/minecraft/class_1733;
 	FIELD field_7251 DROWN Lnet/minecraft/class_1733;
 	FIELD field_7252 STARVE Lnet/minecraft/class_1733;
+	FIELD field_7253 CACTUS Lnet/minecraft/class_1733;
 	FIELD field_7254 FALL Lnet/minecraft/class_1733;
 	FIELD field_7255 OUT_OF_WORLD Lnet/minecraft/class_1733;
 	FIELD field_7256 GENERIC Lnet/minecraft/class_1733;

--- a/mappings/net/minecraft/entity/data/DataTracker.mapping
+++ b/mappings/net/minecraft/entity/data/DataTracker.mapping
@@ -9,6 +9,7 @@ CLASS net/minecraft/class_1761 net/minecraft/entity/data/DataTracker
 	METHOD method_7249 isDirty ()Z
 	METHOD method_7250 getByte (I)B
 		ARG 1 id
+	METHOD method_7251 addEntry (II)V
 	METHOD method_7252 track (ILjava/lang/Object;)V
 		ARG 1 id
 		ARG 2 object

--- a/mappings/net/minecraft/entity/effect/StatusEffect.mapping
+++ b/mappings/net/minecraft/entity/effect/StatusEffect.mapping
@@ -1,10 +1,37 @@
 CLASS net/minecraft/class_1741 net/minecraft/entity/effect/StatusEffect
+	FIELD field_11388 HASTE Lnet/minecraft/class_1741;
+	FIELD field_11389 MINING_FAIGUE Lnet/minecraft/class_1741;
+	FIELD field_11390 INSTANT_HEALTH Lnet/minecraft/class_1741;
+	FIELD field_11391 INSTANT_DAMAGE Lnet/minecraft/class_1741;
+	FIELD field_11392 JUMP_BOOST Lnet/minecraft/class_1741;
+	FIELD field_11393 NAUSEA Lnet/minecraft/class_1741;
 	FIELD field_11394 REGENERATION Lnet/minecraft/class_1741;
+	FIELD field_11395 RESISTANCE Lnet/minecraft/class_1741;
+	FIELD field_11396 FIRE_RESISTANCE Lnet/minecraft/class_1741;
+	FIELD field_11397 WATER_BREATHING Lnet/minecraft/class_1741;
+	FIELD field_11398 INVISIBILITY Lnet/minecraft/class_1741;
+	FIELD field_11399 BLINDNESS Lnet/minecraft/class_1741;
+	FIELD field_11400 NIGHTVISION Lnet/minecraft/class_1741;
+	FIELD field_11401 HUNGER Lnet/minecraft/class_1741;
 	FIELD field_11402 POISON Lnet/minecraft/class_1741;
+	FIELD field_11403 WITHER Lnet/minecraft/class_1741;
+	FIELD field_11404 ABSORPTION Lnet/minecraft/class_1741;
+	FIELD field_11405 SATURATION Lnet/minecraft/class_1741;
+	FIELD field_7277 LEVITATION Lnet/minecraft/class_1741;
+	FIELD field_7278 LUCK Lnet/minecraft/class_1741;
+	FIELD field_7279 BAD_LUCK Lnet/minecraft/class_1741;
+	FIELD field_7280 SLOW_FALLING Lnet/minecraft/class_1741;
+	FIELD field_7281 CONDUIT_POWER Lnet/minecraft/class_1741;
+	FIELD field_7282 DOLPHINS_GRACE Lnet/minecraft/class_1741;
+	FIELD field_7283 BAD_OMEN Lnet/minecraft/class_1741;
 	FIELD field_7284 id I
 	FIELD field_7286 attributeModifiers Ljava/util/Map;
-	FIELD field_7288 color I
+	FIELD field_7287 isHarmfull Z
+	FIELD field_7288 potionColor I
 	FIELD field_7289 translationKey Ljava/lang/String;
+	FIELD field_7290 iconIndex I
+	FIELD field_7291 effectiveness D
+	FIELD field_7292 usable Z
 	FIELD field_7293 STATUS_EFFECTS [Lnet/minecraft/class_1741;
 	FIELD field_7294 UNKNOWN Lnet/minecraft/class_1741;
 	FIELD field_7295 SPEED Lnet/minecraft/class_1741;
@@ -12,14 +39,54 @@ CLASS net/minecraft/class_1741 net/minecraft/entity/effect/StatusEffect
 	FIELD field_7299 STRENGTH Lnet/minecraft/class_1741;
 	FIELD field_7312 WEAKNESS Lnet/minecraft/class_1741;
 	FIELD field_7315 HEALTH_BOOST Lnet/minecraft/class_1741;
+	FIELD field_7318 GLOWING Lnet/minecraft/class_1741;
 	METHOD <init> (IZI)V
 		ARG 1 id
+		ARG 2 isHarmfull
+		ARG 3 potionColor
+	METHOD method_6849 getTranslationKey ()Ljava/lang/String;
+	METHOD method_6850 setEffectiveness (D)Lnet/minecraft/class_1741;
+		ARG 1 effectiveness
 	METHOD method_6851 canApplyUpdateEffect (II)Z
 		ARG 1 duration
 		ARG 2 amplifier
-	METHOD method_6852 (ILnet/minecraft/class_1767;)D
+	METHOD method_6852 getModifier (ILnet/minecraft/class_1767;)D
+		ARG 1 multiplier
 		ARG 2 modifier
+	METHOD method_6853 getDuration (Lnet/minecraft/class_1742;)Ljava/lang/String;
+		ARG 0 effect
+	METHOD method_6854 changHealth (Lnet/minecraft/class_1752;Lnet/minecraft/class_1752;ID)V
+		ARG 1 entity1
+		ARG 2 entity2
+		ARG 3 multiplier
+		ARG 4 amount
+	METHOD method_6855 applyEffect (Lnet/minecraft/class_1752;I)V
+		ARG 1 entity
+		ARG 2 modifier
+	METHOD method_6856 removeFromEntity (Lnet/minecraft/class_1752;Lnet/minecraft/class_2635;I)V
+		ARG 1 entity
+		ARG 2 attributeContainer
+		ARG 3 multiplier
+	METHOD method_6857 setEntityAttribute (Lnet/minecraft/class_1765;Ljava/lang/String;DI)Lnet/minecraft/class_1741;
+		ARG 1 entityAttribute
+		ARG 2 UUID
+		ARG 3 key
+		ARG 5 value
 	METHOD method_6858 isInstant ()Z
+	METHOD method_6859 setIconIndex (II)Lnet/minecraft/class_1741;
+		ARG 1 column
+		ARG 2 row
+	METHOD method_6861 applyToEntity (Lnet/minecraft/class_1752;Lnet/minecraft/class_2635;I)V
+		ARG 1 entity
+		ARG 2 attributeContainer
+		ARG 3 multiplier
+	METHOD method_6863 setPotionName (Ljava/lang/String;)Lnet/minecraft/class_1741;
+		ARG 1 name
 	METHOD method_6864 getId ()I
+	METHOD method_6865 isValidIconIndex ()Z
+	METHOD method_6866 getIconIncex ()I
+	METHOD method_6867 idHarmfull ()Z
+	METHOD method_6868 getEffectiveness ()D
+	METHOD method_6869 isUsable ()Z
 	METHOD method_6870 getColor ()I
 	METHOD method_6871 getAttributeModifiers ()Ljava/util/Map;

--- a/mappings/net/minecraft/entity/player/PlayerEntity.mapping
+++ b/mappings/net/minecraft/entity/player/PlayerEntity.mapping
@@ -19,6 +19,7 @@ CLASS net/minecraft/class_2674 net/minecraft/entity/player/PlayerEntity
 	METHOD <init> (Lnet/minecraft/class_99;Lcom/mojang/authlib/GameProfile;)V
 		ARG 1 world
 		ARG 2 profile
+	METHOD method_10840 addFatigue (F)V
 	METHOD method_10842 trySleep (III)Lnet/minecraft/class_2675;
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/inventory/SidedInventory.mapping
+++ b/mappings/net/minecraft/inventory/SidedInventory.mapping
@@ -1,5 +1,6 @@
 CLASS net/minecraft/class_1730 net/minecraft/inventory/SidedInventory
 	METHOD method_6740 getProperty (I)[I
+		ARG 1 id
 	METHOD method_6797 canInsertInvStack (ILnet/minecraft/class_2056;I)Z
 		ARG 1 slot
 		ARG 2 stack

--- a/mappings/net/minecraft/net/minecraft/block/entity/CrashedBlockDataValueCallable.mapping
+++ b/mappings/net/minecraft/net/minecraft/block/entity/CrashedBlockDataValueCallable.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_2196 net/minecraft/net/minecraft/block/entity/CrashedBlockDataValueCallable
+	FIELD field_9538 anonBlockEntity Lnet/minecraft/class_2193;
+	METHOD <init> (Lnet/minecraft/class_2193;)V
+		ARG 1 blockEntity
+	METHOD call ()Ljava/lang/Object;

--- a/mappings/net/minecraft/screen/SheepScreenHandler.mapping
+++ b/mappings/net/minecraft/screen/SheepScreenHandler.mapping
@@ -1,0 +1,4 @@
+CLASS net/minecraft/class_2653 net/minecraft/screen/SheepScreenHandler
+	FIELD field_7961 sheep Lnet/minecraft/class_1865;
+	METHOD <init> (Lnet/minecraft/class_1865;)V
+		ARG 1 sheep

--- a/mappings/net/minecraft/util/math/Vec3d.mapping
+++ b/mappings/net/minecraft/util/math/Vec3d.mapping
@@ -2,7 +2,13 @@ CLASS net/minecraft/class_649 net/minecraft/util/math/Vec3d
 	FIELD field_9820 x D
 	FIELD field_9821 y D
 	FIELD field_9822 z D
+	METHOD <init> (Lnet/minecraft/class_2683;DDD)V
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
 	METHOD method_2072 normalize ()Lnet/minecraft/class_649;
+	METHOD method_2076 (Lnet/minecraft/class_649;D)Lnet/minecraft/class_649;
+		ARG 1 vec
 	METHOD method_2077 length ()D
 	METHOD method_2078 add (DDD)Lnet/minecraft/class_649;
 		ARG 1 x

--- a/mappings/net/minecraft/util/math/Vec3d.mapping
+++ b/mappings/net/minecraft/util/math/Vec3d.mapping
@@ -1,14 +1,18 @@
 CLASS net/minecraft/class_649 net/minecraft/util/math/Vec3d
+	FIELD field_11793 HELPER Lnet/minecraft/class_2683;
+	FIELD field_11794 helper Lnet/minecraft/class_2683;
 	FIELD field_9820 x D
 	FIELD field_9821 y D
 	FIELD field_9822 z D
 	METHOD <init> (Lnet/minecraft/class_2683;DDD)V
+		ARG 1 vec3dHelper
 		ARG 2 x
 		ARG 4 y
 		ARG 6 z
 	METHOD method_2072 normalize ()Lnet/minecraft/class_649;
-	METHOD method_2076 (Lnet/minecraft/class_649;D)Lnet/minecraft/class_649;
+	METHOD method_2076 getIntermediaryX (Lnet/minecraft/class_649;D)Lnet/minecraft/class_649;
 		ARG 1 vec
+		ARG 2 factor
 	METHOD method_2077 length ()D
 	METHOD method_2078 add (DDD)Lnet/minecraft/class_649;
 		ARG 1 x
@@ -16,10 +20,12 @@ CLASS net/minecraft/class_649 net/minecraft/util/math/Vec3d
 		ARG 5 z
 	METHOD method_2080 dotProduct (Lnet/minecraft/class_649;)D
 		ARG 1 vec
-	METHOD method_2081 (Lnet/minecraft/class_649;D)Lnet/minecraft/class_649;
+	METHOD method_2081 getIntermediaryY (Lnet/minecraft/class_649;D)Lnet/minecraft/class_649;
 		ARG 1 vec
-	METHOD method_2083 (Lnet/minecraft/class_649;D)Lnet/minecraft/class_649;
+		ARG 2 factor
+	METHOD method_2083 getIntermediaryZ (Lnet/minecraft/class_649;D)Lnet/minecraft/class_649;
 		ARG 1 vec
+		ARG 2 factor
 	METHOD method_2086 distanceTo (Lnet/minecraft/class_649;)D
 		ARG 1 vec
 	METHOD method_2087 squaredDistanceTo (Lnet/minecraft/class_649;)D

--- a/mappings/net/minecraft/util/math/vec3dHelper.mapping
+++ b/mappings/net/minecraft/util/math/vec3dHelper.mapping
@@ -1,0 +1,5 @@
+CLASS net/minecraft/class_2683 net/minecraft/util/math/vec3dHelper
+	METHOD method_10930 createVec3d (DDD)Lnet/minecraft/class_649;
+		ARG 1 x
+		ARG 3 y
+		ARG 5 z

--- a/mappings/net/minecraft/util/voxelThreadLocal.mapping
+++ b/mappings/net/minecraft/util/voxelThreadLocal.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_2681 net/minecraft/util/voxelThreadLocal
+	METHOD initialValue newVoxelShape ()Ljava/lang/Object;

--- a/mappings/net/minecraft/world/World.mapping
+++ b/mappings/net/minecraft/world/World.mapping
@@ -114,6 +114,10 @@ CLASS net/minecraft/class_99 net/minecraft/world/World
 		ARG 2 remove
 	METHOD method_291 (Lnet/minecraft/class_646;Lnet/minecraft/class_591;)Z
 		ARG 1 boundingBox
+	METHOD method_292 (Lnet/minecraft/class_646;Lnet/minecraft/class_591;Lnet/minecraft/class_1745;)Z
+		ARG 1 box
+		ARG 2 material
+		ARG 3 entity
 	METHOD method_293 hasEntityIn (Lnet/minecraft/class_646;Lnet/minecraft/class_1745;)Z
 		ARG 1 box
 		ARG 2 exclusion

--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -25,8 +25,9 @@ CLASS net/minecraft/class_113 net/minecraft/world/biome/Biome
 	FIELD field_371 EXTREME_HILLS_PLUS Lnet/minecraft/class_113;
 	FIELD field_372 SAVANNA Lnet/minecraft/class_113;
 	FIELD field_373 SAVANNA_PLATEAU Lnet/minecraft/class_113;
-	FIELD field_374 jungleTreeFeature Lnet/minecraft/class_470;
-	FIELD field_376 oakTreeFeature Lnet/minecraft/class_468;
+	FIELD field_374 treeFeature Lnet/minecraft/class_470;
+	FIELD field_375 largeTreeFeature Lnet/minecraft/class_2209;
+	FIELD field_376 swampTreeFeature Lnet/minecraft/class_468;
 	FIELD field_377 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_378 BIOMES [Lnet/minecraft/class_113;
 	FIELD field_379 OTHER Lnet/minecraft/class_114;
@@ -106,6 +107,7 @@ CLASS net/minecraft/class_113 net/minecraft/world/biome/Biome
 		ARG 2 y
 		ARG 3 z
 	METHOD method_8567 getSpawnEntries (Lnet/minecraft/class_2631;)Ljava/util/List;
+		ARG 1 spawnGroup
 	METHOD method_8568 getGrassColorAt (III)I
 		ARG 1 x
 		ARG 2 y

--- a/mappings/net/minecraft/world/biome/Biome.mapping
+++ b/mappings/net/minecraft/world/biome/Biome.mapping
@@ -25,12 +25,16 @@ CLASS net/minecraft/class_113 net/minecraft/world/biome/Biome
 	FIELD field_371 EXTREME_HILLS_PLUS Lnet/minecraft/class_113;
 	FIELD field_372 SAVANNA Lnet/minecraft/class_113;
 	FIELD field_373 SAVANNA_PLATEAU Lnet/minecraft/class_113;
+	FIELD field_374 jungleTreeFeature Lnet/minecraft/class_470;
+	FIELD field_376 oakTreeFeature Lnet/minecraft/class_468;
 	FIELD field_377 LOGGER Lorg/apache/logging/log4j/Logger;
 	FIELD field_378 BIOMES [Lnet/minecraft/class_113;
 	FIELD field_379 OTHER Lnet/minecraft/class_114;
 	FIELD field_380 MESA Lnet/minecraft/class_113;
 	FIELD field_381 MESA_PLATEAU_F Lnet/minecraft/class_113;
 	FIELD field_382 MESA_PLATEAU Lnet/minecraft/class_113;
+	FIELD field_384 temperatureNoise Lnet/minecraft/class_585;
+	FIELD field_385 foliageNoise Lnet/minecraft/class_585;
 	FIELD field_386 DOUBLE_PLANT_FEATURE Lnet/minecraft/class_440;
 	FIELD field_387 name Ljava/lang/String;
 	FIELD field_390 topBlock Lnet/minecraft/class_160;
@@ -69,6 +73,7 @@ CLASS net/minecraft/class_113 net/minecraft/world/biome/Biome
 	FIELD field_427 RIVER Lnet/minecraft/class_113;
 	FIELD field_428 HELL Lnet/minecraft/class_113;
 	FIELD field_430 FROZEN_OCEAN Lnet/minecraft/class_113;
+	FIELD field_9163 THE_END Lnet/minecraft/class_113;
 	METHOD <init> (I)V
 		ARG 1 id
 	METHOD method_512 createBiomePopulator ()Lnet/minecraft/class_122;
@@ -96,4 +101,12 @@ CLASS net/minecraft/class_113 net/minecraft/world/biome/Biome
 	METHOD method_545 asClass ()Ljava/lang/Class;
 	METHOD method_546 getBiomeTemperature ()Lnet/minecraft/class_2089;
 	METHOD method_547 getBiomes ()[Lnet/minecraft/class_113;
+	METHOD method_8565 getTemperatureAt (III)F
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
 	METHOD method_8567 getSpawnEntries (Lnet/minecraft/class_2631;)Ljava/util/List;
+	METHOD method_8568 getGrassColorAt (III)I
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z

--- a/mappings/net/minecraft/world/gen/AbstractNoiseGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/AbstractNoiseGenerator.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_587 net/minecraft/world/gen/AbstractNoiseGenerator

--- a/mappings/net/minecraft/world/gen/PerlinNoiseGenerator.mapping
+++ b/mappings/net/minecraft/world/gen/PerlinNoiseGenerator.mapping
@@ -1,0 +1,20 @@
+CLASS net/minecraft/class_585 net/minecraft/world/gen/PerlinNoiseGenerator
+	FIELD field_2165 samplers [Lnet/minecraft/class_586;
+	FIELD field_2166 samplersCount I
+	METHOD <init> (Ljava/util/Random;I)V
+		ARG 1 random
+		ARG 2 samplers
+	METHOD method_1793 noise (DD)D
+		ARG 1 x
+		ARG 3 y
+	METHOD method_1794 ([DDDIIDDD)[D
+		ARG 1 array
+		ARG 2 x
+		ARG 4 y
+		ARG 6 xChunkSize
+		ARG 7 yChunkSize
+	METHOD method_1795 ([DDDIIDDDD)[D
+		ARG 1 array
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z

--- a/mappings/net/minecraft/world/gen/feature/OakTreeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/OakTreeFeature.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_468 net/minecraft/world/gen/feature/OakTreeFeature

--- a/mappings/net/minecraft/world/gen/feature/largeTreeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/largeTreeFeature.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_2209 net/minecraft/world/gen/feature/largeTreeFeature

--- a/mappings/net/minecraft/world/gen/feature/swampTreeFeature.mapping
+++ b/mappings/net/minecraft/world/gen/feature/swampTreeFeature.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_468 net/minecraft/world/gen/feature/swampTreeFeature


### PR DESCRIPTION
- more mappings for classes in `net.minecraft.block`
- mappings for noise generators (`PerlinNoiseGenerator` and `AbstractNoiseGenerator`
- more mappings for `vec3d`
- created `vec3dHelper for  `class_2683`
- created a missing goal mapping `class_2646` -> `TemptGoal`
- mapped sprite related classes
- added mappings to some entity related classes
- remapped `JungleTreeFeature` to `TreeFeature` to better represent what the class does
- remapped `OakTreeFeature` -> `SwampTreeFeature`
- mapped missing `TreeFeature`-like in biome to `LargeTreeFeature`
- completed mapping `StatusEffect`
- mapped some remaining stuff in `BlockEntity` and mapped the callables used in the crahs report

ps sorry I had a bunch of unversioned mapping files that I forgot to re-add after changing the name of the class, I added those in this PR as well
